### PR TITLE
fix make all if git config user/email not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ PWD	= $(shell pwd)
 
 
 all:
-	git submodule init
-	git submodule update
-	cd opencv && git am --signoff < ../fix_compiler_crash.patch && cd ..
+	git submodule update --init
+	cd opencv && git reset --hard && git apply < ../fix_compiler_crash.patch && cd ..
 	make cc
 	make build
 	./link.py > install/opencv.xml
-	git submodule update
+	cd opencv && git reset --hard
+
 
 build:
 	make -C ./build


### PR DESCRIPTION
e.g. in the CI environments there is no git user and email set, so you can't use git am
So instead of making the commits, just apply the patch in the workspace.
